### PR TITLE
PEP8 files and allow the cursor for the next pledge page to be returned

### DIFF
--- a/patreon/api.py
+++ b/patreon/api.py
@@ -1,40 +1,42 @@
 import requests
 from datetime import timezone
 
+
 class API(object):
-  def __init__(self, access_token):
-    super(API, self).__init__()
-    self.access_token = access_token
 
-  def fetch_user(self):
-    return self.__get_json('current_user')
+    def __init__(self, access_token):
+        super(API, self).__init__()
+        self.access_token = access_token
 
-  def fetch_campaign_and_patrons(self):
-    return self.__get_json('current_user/campaigns?include=rewards,creator,goals,pledges')
+    def fetch_user(self):
+        return self.__get_json('current_user')
 
-  def fetch_campaign(self):
-    return self.__get_json('current_user/campaigns?include=rewards,creator,goals')
+    def fetch_campaign_and_patrons(self):
+        return self.__get_json('current_user/campaigns?include=rewards,creator,goals,pledges')
 
-  def fetch_page_of_pledges(self, campaign_id, page_size, cursor=None):
-    url = 'campaigns/{0}/pledges?page%5Bcount%5D={1}'.format(campaign_id, str(page_size))
-    if cursor:
-      try:
-        cursor = self.__as_utc(cursor).isoformat()
-      except AttributeError:
-        pass
-      url += '&page%5Bcursor%5D={0}'.format(urllib.parse.quote(cursor))
-    return self.__get_json(url)
+    def fetch_campaign(self):
+        return self.__get_json('current_user/campaigns?include=rewards,creator,goals')
 
-  def __get_json(self, suffix):
-    response = requests.get("https://api.patreon.com/oauth2/api/{}".format(suffix),
-      headers={'Authorization': "Bearer {}".format(self.access_token)})
-    return response.json()
+    def fetch_page_of_pledges(self, campaign_id, page_size, cursor=None):
+        url = 'campaigns/{0}/pledges?page%5Bcount%5D={1}'.format(campaign_id, str(page_size))
+        if cursor:
+            try:
+                cursor = self.__as_utc(cursor).isoformat()
+            except AttributeError:
+                pass
+            url += '&page%5Bcursor%5D={0}'.format(urllib.parse.quote(cursor))
+        return self.__get_json(url)
 
-  @staticmethod
-  def __as_utc(dt):
-    if hasattr(dt, 'tzinfo'):
-      if dt.tzinfo:
-        return dt.astimezone(timezone.utc)
-      else:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt
+    def __get_json(self, suffix):
+        response = requests.get("https://api.patreon.com/oauth2/api/{}".format(suffix),
+                                headers={'Authorization': "Bearer {}".format(self.access_token)})
+        return response.json()
+
+    @staticmethod
+    def __as_utc(dt):
+        if hasattr(dt, 'tzinfo'):
+            if dt.tzinfo:
+                return dt.astimezone(timezone.utc)
+            else:
+                return dt.replace(tzinfo=timezone.utc)
+        return dt

--- a/patreon/api.py
+++ b/patreon/api.py
@@ -1,5 +1,6 @@
 import urllib
 from datetime import timezone
+from urllib.parse import parse_qs, urlparse
 
 import requests
 
@@ -19,19 +20,32 @@ class API(object):
     def fetch_campaign(self):
         return self.__get_json('current_user/campaigns?include=rewards,creator,goals')
 
-    def fetch_page_of_pledges(self, campaign_id, page_size, cursor=None):
+    def fetch_page_of_pledges(self, campaign_id, page_size, cursor=None, return_cursor=False):
         url = 'campaigns/{0}/pledges?page%5Bcount%5D={1}'.format(campaign_id, str(page_size))
+
         if cursor:
             try:
                 cursor = self.__as_utc(cursor).isoformat()
             except AttributeError:
                 pass
             url += '&page%5Bcursor%5D={0}'.format(urllib.parse.quote(cursor))
+
+        if return_cursor:
+            data = self.__get_json(url)
+
+            # Extract the 'cursor'
+            if 'next' in data['links']:
+                query_string = urlparse(data['links']['next']).query
+                parsed_query_string = parse_qs(query_string)
+                cursor = parsed_query_string['page[cursor]'][0]
+
+            return data, cursor
         return self.__get_json(url)
 
     def __get_json(self, suffix):
-        response = requests.get("https://api.patreon.com/oauth2/api/{}".format(suffix),
-                                headers={'Authorization': "Bearer {}".format(self.access_token)})
+        response = requests.get("https://api.patreon.com/oauth2/api/{}".format(suffix), headers={
+            'Authorization': "Bearer {}".format(self.access_token)
+        })
         return response.json()
 
     @staticmethod

--- a/patreon/api.py
+++ b/patreon/api.py
@@ -1,5 +1,7 @@
-import requests
+import urllib
 from datetime import timezone
+
+import requests
 
 
 class API(object):

--- a/patreon/oauth.py
+++ b/patreon/oauth.py
@@ -1,28 +1,30 @@
 import requests
 
+
 class OAuth(object):
-  def __init__(self, client_id, client_secret):
-    super(OAuth, self).__init__()
-    self.client_id = client_id
-    self.client_secret = client_secret
 
-  def get_tokens(self, code, redirect_uri):
-    return self.__update_token({
-        "grant_type": "authorization_code",
-        "code": code,
-        "client_id": self.client_id,
-        "client_secret": self.client_secret,
-        "redirect_uri": redirect_uri
-    })
+    def __init__(self, client_id, client_secret):
+        super(OAuth, self).__init__()
+        self.client_id = client_id
+        self.client_secret = client_secret
 
-  def refresh_token(self, refresh_token, redirect_uri):
-    return self.__update_token({
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": self.client_id,
-        "client_secret": self.client_secret
-    })
+    def get_tokens(self, code, redirect_uri):
+        return self.__update_token({
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "redirect_uri": redirect_uri
+        })
 
-  def __update_token(self, params):
-    response = requests.post("https://api.patreon.com/oauth2/token", params=params)
-    return response.json()
+    def refresh_token(self, refresh_token, redirect_uri):
+        return self.__update_token({
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": self.client_id,
+            "client_secret": self.client_secret
+        })
+
+    def __update_token(self, params):
+        response = requests.post("https://api.patreon.com/oauth2/token", params=params)
+        return response.json()


### PR DESCRIPTION
**Note**: You may need to view the diffs with whitespace changes disabled ([`?w=0`](https://github.com/Patreon/patreon-python/pull/1/files?w=0)).

This pull request contains three changes.  Firstly it runs the project files through a PEP8 checker to ensure they're matching the standard code style for Python projects.  Secondly, it allows the `fetch_page_of_pledges` method to return the cursor for the next page of pledges, this makes it much easier to iterate over the pledges for a campaign. Thirdly, it fixes a missing import (`urllib`) which affects the currently released version.

Example usage:

```python
campaign_id = 123456
per_page = 20

pledges, cursor = api_client.fetch_page_of_pledges(campaign_id, per_page, return_cursor=True)

while 'next' in pledges['links']:
    # Get the next page
    pledges, cursor = api_client.fetch_page_of_pledges(campaign_id, per_page, cursor, return_cursor=True)
```

I've added `return_cursor` as a new kwarg to `fetch_page_of_pledges` with the default value set to `False`, this ensures the code does not break existing installations.

I've only tested this PR against Python 3.5, it may be that the `urllib` import paths are different in Python 2.x. If that's the case, let me know and I'll update the PR with additional imports for Python 2.