### PR TITLE
utility method to extract a pagination cursor from a jsonapi document

### DIFF
--- a/patreon/jsonapi/url_util.py
+++ b/patreon/jsonapi/url_util.py
@@ -1,4 +1,4 @@
-from patreon.version_compatibility.urlencode import urlencode
+from patreon.version_compatibility.urllib_parse import urlencode
 
 
 def build_url(path, includes=None, fields=None):

--- a/patreon/version_compatibility/urlencode.py
+++ b/patreon/version_compatibility/urlencode.py
@@ -1,6 +1,0 @@
-try:
-    # python2
-    from urllib import urlencode
-except ImportError:
-    # python3
-    from urllib.parse import urlencode

--- a/patreon/version_compatibility/urllib_parse.py
+++ b/patreon/version_compatibility/urllib_parse.py
@@ -1,0 +1,7 @@
+try:
+    # python2
+    from urllib import urlencode
+    from urlparse import urlparse, parse_qs
+except ImportError:
+    # python3
+    from urllib.parse import urlencode, urlparse, parse_qs


### PR DESCRIPTION
For paginated jsonapi documents, there will often be pagination links present, typically at `links.next` in the document. Provide a utility method to easily pull out that link's cursor query param.