### PR TITLE
The canonical URL for the Patreon API has moved to patreon.com/api

### DIFF
--- a/patreon/api.py
+++ b/patreon/api.py
@@ -90,7 +90,7 @@ class API(object):
 
     def __get_json(self, suffix):
         response = requests.get(
-            "https://api.patreon.com/oauth2/api/{}".format(suffix),
+            "https://www.patreon.com/api/oauth2/api/{}".format(suffix),
             headers={'Authorization': "Bearer {}".format(self.access_token)}
         )
         return response.json()

--- a/patreon/api_spec.py
+++ b/patreon/api_spec.py
@@ -9,7 +9,7 @@ from patreon.version_compatibility import urllib_parse
 from patreon.version_compatibility.utc_timezone import utc_timezone
 
 MOCK_CAMPAIGN_ID = 12
-API_ROOT_ENDPOINT = 'https://api.patreon.com/oauth2/api/'
+API_ROOT_ENDPOINT = 'https://www.patreon.com/api/oauth2/api/'
 MOCK_ACCESS_TOKEN = 'mock token'
 MOCK_CURSOR_VALUE = 'Mock Cursor Value'
 

--- a/patreon/oauth.py
+++ b/patreon/oauth.py
@@ -27,7 +27,7 @@ class OAuth(object):
     @staticmethod
     def __update_token(params):
         response = requests.post(
-            "https://api.patreon.com/oauth2/token",
+            "https://www.patreon.com/api/oauth2/token",
             params=params
         )
         return response.json()

--- a/patreon/oauth_spec.py
+++ b/patreon/oauth_spec.py
@@ -23,7 +23,7 @@ def test_get_tokens_requests_tokens_as_expected(post, client):
     )
 
     post.assert_called_once_with(
-        'https://api.patreon.com/oauth2/token',
+        'https://www.patreon.com/api/oauth2/token',
         params={
             'grant_type': 'authorization_code',
             'code': MOCK_CODE,
@@ -42,7 +42,7 @@ def test_refresh_token_gets_a_new_token_as_expected(post, client):
     )
 
     post.assert_called_once_with(
-        'https://api.patreon.com/oauth2/token',
+        'https://www.patreon.com/api/oauth2/token',
         params={
             'grant_type': 'refresh_token',
             'refresh_token': MOCK_REFRESH_TOKEN,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     description=DESCRIPTION,
     url='http://github.com/Patreon/patreon-python',
     author='Patreon',
-    author_email='david@patreon.com',
+    author_email='platform@patreon.com',
     license='Apache 2.0',
     packages=find_packages(
         exclude=['examples', 'examples.*', 'test', 'test.*']


### PR DESCRIPTION
We are in the process of changing the canonical URL from `https://api.patreon.com/` to `https://www.patreon.com/api`. This updates the python api client to reflect that.

As a pleasant side-effect, tests now pass in the internal test environment.

cc @LiraNuna 