### PR TITLE
Set user agent with version when making requests

### DIFF
--- a/patreon/api.py
+++ b/patreon/api.py
@@ -3,6 +3,7 @@ import requests
 from patreon.jsonapi.parser import JSONAPIParser
 from patreon.jsonapi.url_util import build_url
 from patreon.schemas import campaign
+from patreon.utils import user_agent_string
 from patreon.version_compatibility.utc_timezone import utc_timezone
 from patreon.version_compatibility.urllib_parse import urlencode, urlparse, parse_qs
 
@@ -91,7 +92,10 @@ class API(object):
     def __get_json(self, suffix):
         response = requests.get(
             "https://www.patreon.com/api/oauth2/api/{}".format(suffix),
-            headers={'Authorization': "Bearer {}".format(self.access_token)}
+            headers={
+                'Authorization': "Bearer {}".format(self.access_token),
+                'User-Agent': user_agent_string(),
+            }
         )
         return response.json()
 

--- a/patreon/api_spec.py
+++ b/patreon/api_spec.py
@@ -5,6 +5,7 @@ import mock
 from patreon import api
 from patreon.jsonapi import url_util
 from patreon.jsonapi.parser import JSONAPIParser
+from patreon.utils import user_agent_string
 from patreon.version_compatibility import urllib_parse
 from patreon.version_compatibility.utc_timezone import utc_timezone
 
@@ -13,7 +14,10 @@ API_ROOT_ENDPOINT = 'https://www.patreon.com/api/oauth2/api/'
 MOCK_ACCESS_TOKEN = 'mock token'
 MOCK_CURSOR_VALUE = 'Mock Cursor Value'
 
-DEFAULT_API_HEADERS = {'Authorization': 'Bearer ' + MOCK_ACCESS_TOKEN}
+DEFAULT_API_HEADERS = {
+    'Authorization': 'Bearer ' + MOCK_ACCESS_TOKEN,
+    'User-Agent': user_agent_string(),
+}
 
 client = api.API(access_token=MOCK_ACCESS_TOKEN)
 

--- a/patreon/oauth.py
+++ b/patreon/oauth.py
@@ -1,5 +1,7 @@
 import requests
 
+from patreon.utils import user_agent_string
+
 
 class OAuth(object):
     def __init__(self, client_id, client_secret):
@@ -28,6 +30,9 @@ class OAuth(object):
     def __update_token(params):
         response = requests.post(
             "https://www.patreon.com/api/oauth2/token",
-            params=params
+            params=params,
+            headers={
+                'User-Agent': user_agent_string(),
+            }
         )
         return response.json()

--- a/patreon/oauth_spec.py
+++ b/patreon/oauth_spec.py
@@ -2,6 +2,7 @@ import mock
 import pytest
 
 from patreon import oauth
+from patreon.utils import user_agent_string
 
 MOCK_CLIENT_ID = 'Mock Client ID'
 MOCK_CLIENT_SECRET = 'Mock Client Secret'
@@ -31,6 +32,9 @@ def test_get_tokens_requests_tokens_as_expected(post, client):
             'client_secret': MOCK_CLIENT_SECRET,
             'redirect_uri': MOCK_REDIRECT_URI,
         },
+        headers={
+            'User-Agent': user_agent_string(),
+        },
     )
 
 
@@ -48,5 +52,8 @@ def test_refresh_token_gets_a_new_token_as_expected(post, client):
             'refresh_token': MOCK_REFRESH_TOKEN,
             'client_id': MOCK_CLIENT_ID,
             'client_secret': MOCK_CLIENT_SECRET,
-        }
+        },
+        headers={
+            'User-Agent': user_agent_string(),
+        },
     )

--- a/patreon/utils.py
+++ b/patreon/utils.py
@@ -1,0 +1,8 @@
+import pkg_resources
+import platform
+
+def user_agent_string():
+	return "Patreon-Python, version {}, platform {}".format(
+		pkg_resources.get_distribution('patreon').version,
+		platform.platform(),
+	)


### PR DESCRIPTION
We want to be able to attribute traffic to our API endpoints to the right platform and client. This will include a user-agent with each request.