### PR TITLE
Add python six module for python compatibility

### DIFF
--- a/patreon/api.py
+++ b/patreon/api.py
@@ -70,10 +70,11 @@ class API(object):
         if current_dict is None or (head is not None and tail is None):
             return None
         # Path stopped before leaf was reached
-        elif current_dict and (type(current_dict) != six.text_type) or type(current_dict != str):
-            raise Exception(
-                'Provided cursor path did not result in a link', current_dict
-            )
+        elif current_dict and type(current_dict) != str:
+            if type(current_dict) != six.text_type:
+                raise Exception(
+                    'Provided cursor path did not result in a link', current_dict
+                )
 
         link = current_dict
         query_string = urlparse(link).query

--- a/patreon/api.py
+++ b/patreon/api.py
@@ -70,7 +70,7 @@ class API(object):
         if current_dict is None or (head is not None and tail is None):
             return None
         # Path stopped before leaf was reached
-        elif current_dict and type(current_dict) != six.text_type:
+        elif current_dict and (type(current_dict) != six.text_type) or type(current_dict != str):
             raise Exception(
                 'Provided cursor path did not result in a link', current_dict
             )

--- a/patreon/api.py
+++ b/patreon/api.py
@@ -70,11 +70,10 @@ class API(object):
         if current_dict is None or (head is not None and tail is None):
             return None
         # Path stopped before leaf was reached
-        elif current_dict and type(current_dict) != str:
-            if type(current_dict) != six.text_type:
-                raise Exception(
-                    'Provided cursor path did not result in a link', current_dict
-                )
+        elif current_dict and type(current_dict) != six.text_type:
+            raise Exception(
+                'Provided cursor path did not result in a link', current_dict
+            )
 
         link = current_dict
         query_string = urlparse(link).query

--- a/patreon/api.py
+++ b/patreon/api.py
@@ -1,11 +1,12 @@
 import requests
+import six
 
 from patreon.jsonapi.parser import JSONAPIParser
 from patreon.jsonapi.url_util import build_url
 from patreon.schemas import campaign
 from patreon.utils import user_agent_string
 from patreon.version_compatibility.utc_timezone import utc_timezone
-from patreon.version_compatibility.urllib_parse import urlencode, urlparse, parse_qs
+from six.moves.urllib.parse import urlparse, parse_qs, urlencode
 
 
 class API(object):
@@ -69,7 +70,7 @@ class API(object):
         if current_dict is None or (head is not None and tail is None):
             return None
         # Path stopped before leaf was reached
-        elif current_dict and type(current_dict) != str:
+        elif current_dict and type(current_dict) != six.text_type:
             raise Exception(
                 'Provided cursor path did not result in a link', current_dict
             )

--- a/patreon/api_spec.py
+++ b/patreon/api_spec.py
@@ -6,8 +6,8 @@ from patreon import api
 from patreon.jsonapi import url_util
 from patreon.jsonapi.parser import JSONAPIParser
 from patreon.utils import user_agent_string
-from patreon.version_compatibility import urllib_parse
 from patreon.version_compatibility.utc_timezone import utc_timezone
+from six.moves.urllib.parse import urlencode
 
 MOCK_CAMPAIGN_ID = 12
 API_ROOT_ENDPOINT = 'https://www.patreon.com/api/oauth2/api/'
@@ -35,7 +35,7 @@ def api_url(*segments, **query):
         del query['includes']
 
     if query:
-        path += '?' + urllib_parse.urlencode(query)
+        path += '?' + urlencode(query)
 
     return url_util.build_url(
         API_ROOT_ENDPOINT + path,

--- a/patreon/api_spec.py
+++ b/patreon/api_spec.py
@@ -1,6 +1,7 @@
 import datetime
 import functools
 import mock
+import six
 
 from patreon import api
 from patreon.jsonapi import url_util
@@ -10,9 +11,10 @@ from patreon.version_compatibility.utc_timezone import utc_timezone
 from six.moves.urllib.parse import urlencode
 
 MOCK_CAMPAIGN_ID = 12
-API_ROOT_ENDPOINT = 'https://www.patreon.com/api/oauth2/api/'
-MOCK_ACCESS_TOKEN = 'mock token'
-MOCK_CURSOR_VALUE = 'Mock Cursor Value'
+API_ROOT_ENDPOINT = six.text_type('https://www.patreon.com/api/oauth2/api/')
+MOCK_ACCESS_TOKEN = six.text_type('mock token')
+MOCK_CURSOR_VALUE = six.text_type('Mock Cursor Value')
+
 
 DEFAULT_API_HEADERS = {
     'Authorization': 'Bearer ' + MOCK_ACCESS_TOKEN,
@@ -23,7 +25,7 @@ client = api.API(access_token=MOCK_ACCESS_TOKEN)
 
 
 def api_url(*segments, **query):
-    path = '/'.join(map(str, segments))
+    path = six.text_type('/').join(map(six.text_type, segments))
 
     fields = query.get('fields', None)
     includes = query.get('includes', None)
@@ -85,10 +87,10 @@ def api_test(method='GET', **response_kwargs):
 def test_extract_cursor_returns_cursor_when_provided():
     assert MOCK_CURSOR_VALUE == api.API.extract_cursor(
         {
-            'links':
+            six.text_type('links'):
                 {
-                    'next':
-                        'https://patreon.com/members?page[cursor]=' +
+                    six.text_type('next'):
+                        six.text_type('https://patreon.com/members?page[cursor]=') +
                         MOCK_CURSOR_VALUE,
                 },
         }
@@ -98,8 +100,8 @@ def test_extract_cursor_returns_cursor_when_provided():
 def test_extract_cursor_returns_None_when_no_cursor_provided():
     assert None is api.API.extract_cursor(
         {
-            'links': {
-                'next': 'https://patreon.com/members?page[offset]=25',
+            six.text_type('links'): {
+                six.text_type('next'): six.text_type('https://patreon.com/members?page[offset]=25'),
             },
         }
     )
@@ -107,8 +109,8 @@ def test_extract_cursor_returns_None_when_no_cursor_provided():
 
 def test_extract_cursor_returns_None_when_link_is_not_a_string():
     assert None is api.API.extract_cursor({
-        'links': {
-            'next': None,
+        six.text_type('links'): {
+            six.text_type('next'): None,
         },
     })
 
@@ -118,8 +120,8 @@ def test_extract_cursor_returns_None_when_link_is_malformed():
 
     try:
         api.API.extract_cursor({
-            'links': {
-                'next': 12,
+            six.text_type('links'): {
+                six.text_type('next'): 12,
             },
         })
 
@@ -132,12 +134,12 @@ def test_extract_cursor_returns_None_when_link_is_malformed():
 
 @api_test()
 def test_can_fetch_user():
-    return api_url('current_user'), client.fetch_user()
+    return api_url(six.text_type('current_user')), client.fetch_user()
 
 
 @api_test()
 def test_can_fetch_campaign():
-    expected_url = api_url('current_user', 'campaigns')
+    expected_url = api_url(six.text_type('current_user'), six.text_type('campaigns'))
     response = client.fetch_campaign()
     return expected_url, response
 
@@ -147,9 +149,9 @@ def test_can_fetch_api_and_patrons():
     response = client.fetch_campaign_and_patrons()
 
     expected_url = api_url(
-        'current_user',
-        'campaigns',
-        includes=['rewards', 'creator', 'goals', 'pledges'],
+        six.text_type('current_user'),
+        six.text_type('campaigns'),
+        includes=[six.text_type('rewards'), six.text_type('creator'), six.text_type('goals'), six.text_type('pledges')],
     )
 
     return expected_url, response

--- a/patreon/jsonapi/url_util.py
+++ b/patreon/jsonapi/url_util.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
-
-from patreon.version_compatibility.urllib_parse import urlencode
+from six.moves.urllib.parse import urlencode
 
 
 def joined_or_null(arr):

--- a/patreon/version_compatibility/urllib_parse.py
+++ b/patreon/version_compatibility/urllib_parse.py
@@ -1,7 +1,0 @@
-try:
-    # python2
-    from urllib import urlencode
-    from urlparse import urlparse, parse_qs
-except ImportError:
-    # python3
-    from urllib.parse import urlencode, urlparse, parse_qs


### PR DESCRIPTION
Addressing issue #19 Error in extract_cursor() method (https://github.com/Patreon/patreon-python/issues/19)
Problem:
- Users using python 2.7 can't retrieve all pledges to a campaign because the api returns a dict with unicode instead of string which causes an error to be thrown when iterating through a creator's pages ( see api.py line 73 for reference)

Solution:
- Import the python six module that allows the conditional to handle both unicode and string (six.text_type)
- Also removed the urllib_parse file and replaced it with six imports instead